### PR TITLE
kubernetes-intro v0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # vradnit_platform
 vradnit Platform repository
+
+
+
+
+# ДЗ-1 Kubernetes-intro
+
+1. Установлен minikub
+
+2. При удалении подов через "kubectl delete":
+   kube-proxy - создается заново с помощью контроллера daemonset ( на всех нодах с меткой kubernetes.io/os=linux )
+   coredns    - создается заново с помощью контроллера replicaset ( который поддеживает кол-во подов 1 штука )
+   etcd-minikube, kube-apiserver-minikube, kube-controller-manager-minikube, kube-scheduler-minikube - не изменяют свое состояние
+     т.к. контроллируются сервисом kubelet ( из статических манифестов )
+
+   При удалении контейнеров через "docker rm", контейнеры пересоздаются,
+   т.к. kubelet контроллирует работоспособность контейнеров и стартует их заново.
+
+3. Создан kubernetes-intro/web/Dockerfile
+   В качестве web сервера используется httpd из образа busybox.
+   Образ сохранен на dockerhub в vradnit/web:0.1
+
+4. Создан kubernetes-intro/web-pod.yaml
+   В качестве основного контейнера используется образ vradnit/web:0.1
+   В качестве init контейнера используется образ "busybox c wget".
+   Init контейнер необходим для "первоначального заполнения" директории /app
+
+5. Используя https://github.com/GoogleCloudPlatform/microservices-demo/blob/master/src/frontend/Dockerfile , создан docker образ.
+   Образ сохранен на dockerhub в vradnit/hipster-frontend:v0.0.1
+   C помошью "kubectl run ... --dry-run" создан манифест пода frontend.
+   После создания пода, его статус "error".
+   Анализ его лога "kubectl logs frontend" подсказал причину ошибки "нет необходимых переменных окружения".
+   Необходимые переменные окружения найдены в src main.go
+   Исправленный манифест сохранен в kubernetes-intro/frontend-pod-healthy.yaml

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: vradnit/hipster-frontend:v0.0.1
+    name: frontend
+    env:
+    - name: LISTEN_ADDR
+      value: "0.0.0.0"
+    - name: PORT
+      value: "8000"
+    - name: PRODUCT_CATALOG_SERVICE_ADDR
+      value: "192.168.0.1"
+    - name: CURRENCY_SERVICE_ADDR
+      value: "192.168.0.2"
+    - name: CART_SERVICE_ADDR
+      value: "192.168.0.3"
+    - name: RECOMMENDATION_SERVICE_ADDR
+      value: "192.168.0.4"
+    - name: CHECKOUT_SERVICE_ADDR
+      value: "192.168.0.5"
+    - name: SHIPPING_SERVICE_ADDR
+      value: "192.168.0.6"
+    - name: AD_SERVICE_ADDR
+      value: "192.168.0.7"
+    resources: {}
+    ports:
+    - name: http
+      containerPort: 8000
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    web: app
+spec:
+  containers:
+  - name: web
+    image: vradnit/web:0.1
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  initContainers:
+  - name: init
+    image: busybox:1.35
+    command: ['sh', '-c', 'wget -O - https://tinyurl.com/otus-k8s-intro | sh']
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  volumes:
+  - name: app
+    emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,7 @@
+FROM busybox:1.35
+
+USER 1001:1001
+
+WORKDIR /app
+
+CMD ["/bin/httpd", "-f", "-v", "-p", "8000"]


### PR DESCRIPTION
# Выполнено ДЗ №1

1. Установлен minikub

2. При удалении подов через "kubectl delete":
   kube-proxy - создается заново с помощью контроллера daemonset ( на всех нодах с меткой kubernetes.io/os=linux )
   coredns    - создается заново с помощью контроллера replicaset ( который поддеживает кол-во подов 1 штука )
   etcd-minikube, kube-apiserver-minikube, kube-controller-manager-minikube, kube-scheduler-minikube - не изменяют свое состояние
     т.к. контроллируются сервисом kubelet ( из статических манифестов )

   При удалении контейнеров через "docker rm", контейнеры пересоздаются,
   т.к. kubelet контроллирует работоспособность контейнеров и стартует их заново.

3. Создан kubernetes-intro/web/Dockerfile
   В качестве web сервера используется httpd из образа busybox.
   Образ сохранен на dockerhub в vradnit/web:0.1

4. Создан kubernetes-intro/web-pod.yaml
   В качестве основного контейнера используется образ vradnit/web:0.1
   В качестве init контейнера используется образ "busybox c wget".
   Init контейнер необходим для "первоначального заполнения" директории /app

5. Используя https://github.com/GoogleCloudPlatform/microservices-demo/blob/master/src/frontend/Dockerfile , создан docker образ.
   Образ сохранен на dockerhub в vradnit/hipster-frontend:v0.0.1
   C помошью "kubectl run ... --dry-run" создан манифест пода frontend.
   После создания пода, его статус "error".
   Анализ его лога "kubectl logs frontend" подсказал причину ошибки "нет необходимых переменных окружения".
   Необходимые переменные окружения найдены в src main.go
   Исправленный манифест сохранен в kubernetes-intro/frontend-pod-healthy.yaml