### PR TITLE
Kubernetes volumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 infra/
+kubernetes-volumes/.kube/

--- a/README.md
+++ b/README.md
@@ -75,3 +75,26 @@ vradnit Platform repository
 8. Создан манифест daemonset kubernetes-controllers/node-exporter-daemonset.yaml для развертывания NodeExporter.
    Для того чтобы daemonset запустил под на мастер ноде в манифест добавлен "tolerations" на taints 
    "node-role.kubernetes.io/control-plane:NoSchedule"
+
+
+
+
+# ДЗ-4 Kubernetes-volumes
+
+1. С помощью kind установлен однонодовый кластер kubernetes
+
+2. Развернут statefulset Minio "kubernetes-volumes/minio-statefulset.yaml"
+   ( оригинал https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Kuberenetes-volumes/minio-statefulset.yaml )
+
+3. Развернут headless service для minio "kubernetes-volumes/minio-headless-service.yaml"
+   ( оригинал https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Kuberenetes-volumes/minio-headless-service.yaml )
+
+4. Проверки работы компонентов инстанса минио:
+   kubectl get statefulsets
+   kubectl get pods
+   kubectl get pvc
+   kubectl get pv
+   kubectl describe <resource> <resource_name>
+
+5. Для более "безопасного" хранения секретов, создан secret "kubernetes-volumes/minio-secrets.yaml"
+   Манифест statefulset-a "kubernetes-volumes/minio-statefulset.yaml" переконфигурирован на использование этого secret

--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-secrets.yaml
+++ b/kubernetes-volumes/minio-secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  MINIO_ACCESS_KEY: bWluaW8=
+  MINIO_SECRET_KEY: bWluaW8xMjM=
+kind: Secret
+metadata:
+  name: minio-secrets

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        envFrom:
+        - secretRef:
+            name: minio-secrets
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
# ДЗ-4 Kubernetes-volumes

1. С помощью kind установлен однонодовый кластер kubernetes

2. Развернут statefulset Minio "kubernetes-volumes/minio-statefulset.yaml"
   ( оригинал https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Kuberenetes-volumes/minio-statefulset.yaml )

3. Развернут headless service для minio "kubernetes-volumes/minio-headless-service.yaml"
   ( оригинал https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Kuberenetes-volumes/minio-headless-service.yaml )

4. Проверки работы компонентов инстанса минио:
   kubectl get statefulsets
   kubectl get pods
   kubectl get pvc
   kubectl get pv
   kubectl describe <resource> <resource_name>

5. Для более "безопасного" хранения секретов, создан secret "kubernetes-volumes/minio-secrets.yaml"
   Манифест statefulset-a "kubernetes-volumes/minio-statefulset.yaml" переконфигурирован на использование этого secret