### PR TITLE
DZ-5 kubernetes-security: init commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,52 @@ vradnit Platform repository
 8. Создан манифест daemonset kubernetes-controllers/node-exporter-daemonset.yaml для развертывания NodeExporter.
    Для того чтобы daemonset запустил под на мастер ноде в манифест добавлен "tolerations" на taints 
    "node-role.kubernetes.io/control-plane:NoSchedule"
+
+
+
+
+# ДЗ-5 Kubernetes-security
+
+1. С помощью kind установлен однонодовый кластер kubernetes.
+
+2. task01:
+   . создан serviceaccount bob и ему выдана роль admin на весь кластер
+     task01/01-serviceaccount-bob.yaml
+     task01/02-clusterrolebinding-admin-bob.yaml
+     
+   . создан serviceaccount dave без доступа к кластеру
+     task01/03-serviceaccount-dave.yaml
+
+   . проверка:
+     kubectl auth can-i --list --as=system:serviceaccount:default:bob --namespace=xxx
+     kubectl auth can-i --list --as=system:serviceaccount:default:dave --namespace=default
+
+3. task02:
+   . создан неймспейс "prometheus" и в нем создан ServiceAccount "carol"
+     task02/01-namespace-prometheus.yaml
+     task02/02-serviceaccount-carol.yaml
+
+   . Всем ServiceAccount в неймспейсе "prometheus" выданы права на "get/list/watch" в отношении "Pod" для всего кластера
+     task02/03-clusterrole-for-ns-prometheus.yaml
+     task02/04-clusterrolebinding-for-ns-prometheus.yaml
+
+   . проверка:
+     kubectl auth can-i --list --as=system:serviceaccount:prometheus:xxx --namespace=kube-system
+     kubectl auth can-i --list --as=system:serviceaccount:xxx:xxx --namespace=kube-system
+
+4. task03:
+   . создан неймспейс "dev", в нем ServiceAccount "jane" с ролью "admin" в рамках этого неймспейса
+     task03/01-namespace-dev.yaml
+     task03/02-serviceaccount-jane.yaml
+     task03/03-clusterrolebinding-jane.yaml
+
+   . в неймспейсе "dev" создан ServiceAccount "ken" с ролью "view" в рамках этого неймспейса
+     task03/04-serviceaccount-ken.yaml
+     task03/05-clusterrolebinding-ken.yaml
+   
+   . проверка: 
+     kubectl auth can-i --list --as=system:serviceaccount:dev:jane --namespace=dev
+     kubectl auth can-i --list --as=system:serviceaccount:dev:jane --namespace=kube-system
+
+     kubectl auth can-i --list --as=system:serviceaccount:dev:ken --namespace=dev
+     kubectl auth can-i --list --as=system:serviceaccount:dev:ken --namespace=kube-system

--- a/kubernetes-security/task01/01-serviceaccount-bob.yaml
+++ b/kubernetes-security/task01/01-serviceaccount-bob.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bob
+  namespace: default

--- a/kubernetes-security/task01/02-clusterrolebinding-admin-bob.yaml
+++ b/kubernetes-security/task01/02-clusterrolebinding-admin-bob.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-bob
+subjects:
+- kind: ServiceAccount
+  name: bob
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-security/task01/03-serviceaccount-dave.yaml
+++ b/kubernetes-security/task01/03-serviceaccount-dave.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dave
+  namespace: default

--- a/kubernetes-security/task02/01-namespace-prometheus.yaml
+++ b/kubernetes-security/task02/01-namespace-prometheus.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prometheus

--- a/kubernetes-security/task02/02-serviceaccount-carol.yaml
+++ b/kubernetes-security/task02/02-serviceaccount-carol.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: carol
+  namespace: prometheus

--- a/kubernetes-security/task02/03-clusterrole-for-ns-prometheus.yaml
+++ b/kubernetes-security/task02/03-clusterrole-for-ns-prometheus.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusterrole-for-ns-prometheus
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/kubernetes-security/task02/04-clusterrolebinding-for-ns-prometheus.yaml
+++ b/kubernetes-security/task02/04-clusterrolebinding-for-ns-prometheus.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clusterrolebinding-for-ns-prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterrole-for-ns-prometheus
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:prometheus

--- a/kubernetes-security/task03/01-namespace-dev.yaml
+++ b/kubernetes-security/task03/01-namespace-dev.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev

--- a/kubernetes-security/task03/02-serviceaccount-jane.yaml
+++ b/kubernetes-security/task03/02-serviceaccount-jane.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jane
+  namespace: dev

--- a/kubernetes-security/task03/03-rolebinding-jane.yaml
+++ b/kubernetes-security/task03/03-rolebinding-jane.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dev-admin
+  namespace: dev
+subjects:
+- kind: ServiceAccount
+  name: jane
+  namespace: dev
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-security/task03/04-serviceaccount-ken.yaml
+++ b/kubernetes-security/task03/04-serviceaccount-ken.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ken
+  namespace: dev

--- a/kubernetes-security/task03/05-rolebinding-ken.yaml
+++ b/kubernetes-security/task03/05-rolebinding-ken.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dev-view
+  namespace: dev
+subjects:
+- kind: ServiceAccount
+  name: ken
+  namespace: dev
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
# ДЗ-5 Kubernetes-security

1. С помощью kind установлен однонодовый кластер kubernetes.

2. task01:
   . создан serviceaccount bob и ему выдана роль admin на весь кластер
     task01/01-serviceaccount-bob.yaml
     task01/02-clusterrolebinding-admin-bob.yaml
     
   . создан serviceaccount dave без доступа к кластеру
     task01/03-serviceaccount-dave.yaml

   . проверка:
     kubectl auth can-i --list --as=system:serviceaccount:default:bob --namespace=xxx
     kubectl auth can-i --list --as=system:serviceaccount:default:dave --namespace=default

3. task02:
   . создан неймспейс "prometheus" и в нем создан ServiceAccount "carol"
     task02/01-namespace-prometheus.yaml
     task02/02-serviceaccount-carol.yaml

   . Всем ServiceAccount в неймспейсе "prometheus" выданы права на "get/list/watch" в отношении "Pod" для всего кластера
     task02/03-clusterrole-for-ns-prometheus.yaml
     task02/04-clusterrolebinding-for-ns-prometheus.yaml

   . проверка:
     kubectl auth can-i --list --as=system:serviceaccount:prometheus:xxx --namespace=kube-system
     kubectl auth can-i --list --as=system:serviceaccount:xxx:xxx --namespace=kube-system

4. task03:
   . создан неймспейс "dev", в нем ServiceAccount "jane" с ролью "admin" в рамках этого неймспейса
     task03/01-namespace-dev.yaml
     task03/02-serviceaccount-jane.yaml
     task03/03-clusterrolebinding-jane.yaml

   . в неймспейсе "dev" создан ServiceAccount "ken" с ролью "view" в рамках этого неймспейса
     task03/04-serviceaccount-ken.yaml
     task03/05-clusterrolebinding-ken.yaml
   
   . проверка: 
     kubectl auth can-i --list --as=system:serviceaccount:dev:jane --namespace=dev
     kubectl auth can-i --list --as=system:serviceaccount:dev:jane --namespace=kube-system

     kubectl auth can-i --list --as=system:serviceaccount:dev:ken --namespace=dev
     kubectl auth can-i --list --as=system:serviceaccount:dev:ken --namespace=kube-system